### PR TITLE
Enable github workflows to run python linter

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3
@@ -31,10 +31,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        # stop the build if there are linter errors (ignore complexity metrics)
+        flake8 . --count --max-line-length=127 --max-complexity=1000 --show-source --statistics
+        # output complexity metrics
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -203,7 +203,6 @@ class DataWareHouse:
             elif line_num == 5:
                 start, end = line
             elif line_num == 7:
-                timeunit = line[0]
                 dimensions = []
                 for label in line[1:]:
                     match = labelre.match(label)
@@ -321,7 +320,7 @@ class DataWareHouse:
 
         code = self.crl.getinfo(pycurl.RESPONSE_CODE)
         if code != 200:
-           raise RuntimeError('Error ' + str(code) + ' ' + get_body.decode('utf8'))
+            raise RuntimeError('Error ' + str(code) + ' ' + get_body.decode('utf8'))
 
         result = json.loads(get_body.decode('utf8'))
         return pd.DataFrame(result['data'], columns=result['stats'], dtype=numpy.float64)
@@ -330,9 +329,7 @@ class DataWareHouse:
         groups = []
         data = []
         for line_num, line in enumerate(rd):
-            if line_num == 1:
-                title = line[0]
-            elif line_num == 5:
+            if line_num == 5:
                 start, end = line
             elif line_num == 7:
                 group, metric = line
@@ -368,19 +365,19 @@ class DataWareHouse:
 
         if response['success']:
             jobs = [job for job in response['result']]
-            dates = [date.strftime("%Y-%m-%d") for date in pd.date_range(params['start'], params['end'],freq='D').date]
+            dates = [date.strftime("%Y-%m-%d") for date in pd.date_range(params['start'], params['end'], freq='D').date]
 
             quality = numpy.empty((len(jobs), len(dates)))
 
             for i in range(len(jobs)):
                 for j in range(len(dates)):
                     if response['result'][jobs[i]].get(dates[j], numpy.nan) != 'N/A':
-                        quality[i,j] = response['result'][jobs[i]].get(dates[j], numpy.nan)
+                        quality[i, j] = response['result'][jobs[i]].get(dates[j], numpy.nan)
                     else:
-                        quality[i,j] = numpy.nan
+                        quality[i, j] = numpy.nan
             if is_numpy:
                 return quality
-            df = pd.DataFrame(data= quality, index=jobs, columns = dates)
+            df = pd.DataFrame(data=quality, index=jobs, columns=dates)
             df.name = type_to_title[params['type']]
             return df
         else:

--- a/xdmod/themes.py
+++ b/xdmod/themes.py
@@ -2,12 +2,74 @@ import plotly.graph_objects as go
 import plotly.io as pio
 
 pio.templates["timeseries"] = go.layout.Template(
-    layout = {
+    layout={
         'hoverlabel': {
             'bgcolor': 'white'
         },
         'plot_bgcolor': 'white',
-        'colorway':   [ "#1199FF","#DB4230","#4E665D","#F4A221","#66FF00","#33ABAB","#A88D95","#789ABC","#FF99CC","#00CCFF","#FFBC71","#A57E81","#8D4DFF","#FF6666","#CC99FF","#2F7ED8","#0D233A","#8BBC21","#910000","#1AADCE","#492970","#F28F43","#77A1E5","#3366FF","#FF6600","#808000","#CC99FF","#008080","#CC6600","#9999FF","#99FF99","#969696","#FF00FF","#FFCC00","#666699","#00FFFF","#00CCFF","#993366","#3AAAAA","#C0C0C0","#FF99CC","#FFCC99","#CCFFCC","#CCFFFF","#99CCFF","#339966","#FF9966","#69BBED","#33FF33","#6666FF","#FF66FF","#99ABAB","#AB8722","#AB6565","#990099","#999900","#CC3300","#669999","#993333","#339966","#C42525","#A6C96A","#111111"],
+        'colorway': ["#1199FF",
+                     "#DB4230",
+                     "#4E665D",
+                     "#F4A221",
+                     "#66FF00",
+                     "#33ABAB",
+                     "#A88D95",
+                     "#789ABC",
+                     "#FF99CC",
+                     "#00CCFF",
+                     "#FFBC71",
+                     "#A57E81",
+                     "#8D4DFF",
+                     "#FF6666",
+                     "#CC99FF",
+                     "#2F7ED8",
+                     "#0D233A",
+                     "#8BBC21",
+                     "#910000",
+                     "#1AADCE",
+                     "#492970",
+                     "#F28F43",
+                     "#77A1E5",
+                     "#3366FF",
+                     "#FF6600",
+                     "#808000",
+                     "#CC99FF",
+                     "#008080",
+                     "#CC6600",
+                     "#9999FF",
+                     "#99FF99",
+                     "#969696",
+                     "#FF00FF",
+                     "#FFCC00",
+                     "#666699",
+                     "#00FFFF",
+                     "#00CCFF",
+                     "#993366",
+                     "#3AAAAA",
+                     "#C0C0C0",
+                     "#FF99CC",
+                     "#FFCC99",
+                     "#CCFFCC",
+                     "#CCFFFF",
+                     "#99CCFF",
+                     "#339966",
+                     "#FF9966",
+                     "#69BBED",
+                     "#33FF33",
+                     "#6666FF",
+                     "#FF66FF",
+                     "#99ABAB",
+                     "#AB8722",
+                     "#AB6565",
+                     "#990099",
+                     "#999900",
+                     "#CC3300",
+                     "#669999",
+                     "#993333",
+                     "#339966",
+                     "#C42525",
+                     "#A6C96A",
+                     "#111111"],
         'xaxis': {
             'titlefont': {
                 'family': 'Arial, sans-serif',
@@ -42,8 +104,8 @@ pio.templates["timeseries"] = go.layout.Template(
         'title': {
             'font': {
                 'color': '#444b6e',
-                    'size': 16
-                }
+                'size': 16
+            }
         },
         'hovermode': 'closest',
         'showlegend': True,


### PR DESCRIPTION
This enables a python linter (with mostly default rules) and updates the source code to match the rules! If the default
set of rules are too restrictive we can always make them more lenient.

pylint can be run in the workflow - it is currently disabled due to not having any tests to run. Once tests are added we can enable it.