### PR TITLE
Add processing for filters, duration, aggregation unit, and specifying metrics/dimensions via labels; move duplicated code into methods

### DIFF
--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -76,18 +76,18 @@ class DataWareHouse:
             return self.logged_in
         return 'Not logged in'
 
-    def realms(self):
+    def get_realms(self):
         info = self.__get_descriptor()
         return [*info['realms']]
 
-    def metrics(self, realm):
+    def get_metrics(self, realm):
         info = self.__get_descriptor()
         output = []
         for metric, minfo in info['realms'][realm]['metrics'].items():
             output.append((metric, minfo['text'] + ': ' + minfo['info']))
         return output
 
-    def dimensions(self, realm):
+    def get_dimensions(self, realm):
         info = self.__get_descriptor()
         output = []
         for dimension, dinfo in info['realms'][realm]['dimensions'].items():

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -74,7 +74,7 @@ class DataWareHouse:
     def whoami(self):
         if self.logged_in:
             return self.logged_in
-        return "Not logged in"
+        return 'Not logged in'
 
     def realms(self):
         info = self.get_descriptor()
@@ -146,8 +146,8 @@ class DataWareHouse:
         for resource in cdata['metaData']['fields']:
             if resource['name'] == 'requirement':
                 continue
-            names.append(resource['header'][:-7].split(">")[1].replace('-', ' '))
-            types.append(resource['status'].split("|")[0].strip())
+            names.append(resource['header'][:-7].split('>')[1].replace('-', ' '))
+            types.append(resource['status'].split('|')[0].strip())
             resource_ids.append(resource['resource_id'])
 
         return pd.Series(data=types, index=names)
@@ -210,14 +210,14 @@ class DataWareHouse:
                     else:
                         dimensions.append(html.unescape(label))
             elif line_num > 7 and len(line) > 1:
-                if re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$", line[0]):
-                    timestamps.append(datetime.strptime(line[0], "%Y-%m-%d"))
+                if re.match(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$', line[0]):
+                    timestamps.append(datetime.strptime(line[0], '%Y-%m-%d'))
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
-                elif re.match(r"^[0-9]{4}-[0-9]{2}$", line[0]):
-                    timestamps.append(datetime.strptime(line[0], "%Y-%m"))
+                elif re.match(r'^[0-9]{4}-[0-9]{2}$', line[0]):
+                    timestamps.append(datetime.strptime(line[0], '%Y-%m'))
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
-                elif re.match(r"^[0-9]{4} Q[0-9]$", line[0]):
-                    year, quarter = line[0].split(" ")
+                elif re.match(r'^[0-9]{4} Q[0-9]$', line[0]):
+                    year, quarter = line[0].split(' ')
                     dstamp = ''
                     if quarter == 'Q1':
                         dstamp = year + '-01-01'
@@ -228,13 +228,13 @@ class DataWareHouse:
                     elif quarter == 'Q4':
                         dstamp = year + '-10-01'
                     else:
-                        raise Exception("Unsupported date quarter specification " + line[0])
+                        raise Exception('Unsupported date quarter specification ' + line[0])
 
                     timestamps.append(datetime.strptime(dstamp, '%Y-%m-%d'))
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
                 else:
                     # TODO handle other date cases
-                    raise Exception("Unsupported date specification " + line[0])
+                    raise Exception('Unsupported date specification ' + line[0])
 
         return (pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions), title)
 
@@ -310,7 +310,7 @@ class DataWareHouse:
 
         b_obj = io.BytesIO()
         self.crl.setopt(pycurl.WRITEDATA, b_obj)
-        headers = self.headers + ["Accept: application/json", "Content-Type: application/json", "charset: utf-8"]
+        headers = self.headers + ['Accept: application/json', 'Content-Type: application/json', 'charset: utf-8']
         self.crl.setopt(pycurl.HTTPHEADER, headers)
         self.crl.setopt(pycurl.POSTFIELDS, request)
         self.crl.perform()
@@ -364,7 +364,7 @@ class DataWareHouse:
 
         if response['success']:
             jobs = [job for job in response['result']]
-            dates = [date.strftime("%Y-%m-%d") for date in pd.date_range(params['start'], params['end'], freq='D').date]
+            dates = [date.strftime('%Y-%m-%d') for date in pd.date_range(params['start'], params['end'], freq='D').date]
 
             quality = numpy.empty((len(jobs), len(dates)))
 

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -25,6 +25,11 @@ class DataWareHouse:
         self.sslverify = sslverify
         self.headers = []
 
+        self.VALID_VALUES = {
+            'dataset_type': (
+                'timeseries',
+                'aggregate')}
+
         if not self.apikey:
             try:
                 self.apikey = {
@@ -194,6 +199,8 @@ class DataWareHouse:
         metric_id = self.__get_id_from_descriptor(realm, 'metrics', metric)
         dimension_id = self.__get_id_from_descriptor(realm, 'dimensions', dimension)
 
+        self.__validate_str('dataset_type', dataset_type)
+
         config = {
             'operation': 'get_data',
             'start_date': start,
@@ -298,6 +305,12 @@ class DataWareHouse:
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
 
             return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
+
+    def __validate_str(self, key, value):
+        self.__assert_str(key, value)
+        if value not in self.VALID_VALUES[key]:
+            raise KeyError('Invalid ' + key + ' \'' + value +
+                           '\'. Valid values are: ' + str(self.VALID_VALUES[key]))
 
     def __get_id_from_descriptor(self, realm, key, id):
         list = self.__get_descriptor_id_text_info_list(realm, key)

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -104,18 +104,17 @@ class DataWareHouse:
         return tuple([*descriptor['realms']])
 
     def get_metrics(self, realm):
-        info = self.__get_descriptor()
-        output = []
-        for metric, minfo in info['realms'][realm]['metrics'].items():
-            output.append((metric, minfo['text'] + ': ' + minfo['info']))
-        return output
+        return self.__get_descriptor_data_frame(realm, 'metrics')
+
+    def __get_descriptor_data_frame(self, realm, key):
+        df = self.__get_indexed_data_frame(
+            data=self.__get_descriptor_id_text_info_list(realm, key),
+            columns=('id', 'label', 'description'),
+            index='id')
+        return df
 
     def get_dimensions(self, realm):
-        info = self.__get_descriptor()
-        output = []
-        for dimension, dinfo in info['realms'][realm]['dimensions'].items():
-            output.append((dimension, dinfo['text'] + ': ' + dinfo['info']))
-        return output
+        return self.__get_descriptor_data_frame(realm, 'dimensions')
 
     def __get_descriptor(self):
         if self.descriptor:

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -276,7 +276,7 @@ class DataWareHouse:
                         # TODO handle other date cases
                         raise Exception('Unsupported date specification ' + line[0])
 
-            return (pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions), title)
+            return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
 
     def get_usagedata(self, config):
         response = self.__request('/controllers/user_interface.php',

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -77,24 +77,24 @@ class DataWareHouse:
         return 'Not logged in'
 
     def realms(self):
-        info = self.get_descriptor()
+        info = self.__get_descriptor()
         return [*info['realms']]
 
     def metrics(self, realm):
-        info = self.get_descriptor()
+        info = self.__get_descriptor()
         output = []
         for metric, minfo in info['realms'][realm]['metrics'].items():
             output.append((metric, minfo['text'] + ': ' + minfo['info']))
         return output
 
     def dimensions(self, realm):
-        info = self.get_descriptor()
+        info = self.__get_descriptor()
         output = []
         for dimension, dinfo in info['realms'][realm]['dimensions'].items():
             output.append((dimension, dinfo['text'] + ': ' + dinfo['info']))
         return output
 
-    def get_descriptor(self):
+    def __get_descriptor(self):
         if self.descriptor:
             return self.descriptor
 

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -1,16 +1,15 @@
-from datetime import datetime
-import io
-import tempfile
-import json
-import os
 import csv
-from urllib.parse import urlencode
-import re
+from datetime import datetime
 import html
-
+import io
+import json
 import numpy
-import pycurl
+import os
 import pandas as pd
+import pycurl
+import re
+import tempfile
+from urllib.parse import urlencode
 
 
 class DataWareHouse:

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -193,16 +193,17 @@ class DataWareHouse:
                     aggregation_unit='Auto'):
 
         config = {
+            'operation': 'get_data',
             'start_date': start,
             'end_date': end,
             'realm': realm,
             'statistic': metric,
             'group_by': dimension,
+            'dataset_type': dataset_type,
+            'aggregation_unit': aggregation_unit,
             'public_user': 'true',
             'timeframe_label': '2016',
             'scale': '1',
-            'aggregation_unit': aggregation_unit,
-            'dataset_type': dataset_type,
             'thumbnail': 'n',
             'query_group': 'po_usage',
             'display_type': 'line',
@@ -222,7 +223,6 @@ class DataWareHouse:
             'legend_type': 'bottom_center',
             'font_size': '3',
             'inline': 'n',
-            'operation': 'get_data',
             'format': 'csv'
         }
 

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -248,31 +248,36 @@ class DataWareHouse:
                         else:
                             dimensions.append(html.unescape(label))
                 elif line_num > 7 and len(line) > 1:
+                    date_string = line[0]
+                    # Match YYYY-MM-DD
                     if re.match(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$', line[0]):
-                        timestamps.append(datetime.strptime(line[0], '%Y-%m-%d'))
-                        data.append(numpy.asarray(line[1:], dtype=numpy.float64))
+                        format = '%Y-%m-%d'
+                    # Match YYYY-MM
                     elif re.match(r'^[0-9]{4}-[0-9]{2}$', line[0]):
-                        timestamps.append(datetime.strptime(line[0], '%Y-%m'))
-                        data.append(numpy.asarray(line[1:], dtype=numpy.float64))
+                        format = '%Y-%m'
+                    # Match YYYY
+                    elif re.match(r'^[0-9]{4}$', line[0]):
+                        format = '%Y'
+                    # Match YYYY Q#
                     elif re.match(r'^[0-9]{4} Q[0-9]$', line[0]):
                         year, quarter = line[0].split(' ')
-                        dstamp = ''
                         if quarter == 'Q1':
-                            dstamp = year + '-01-01'
+                            month = '01'
                         elif quarter == 'Q2':
-                            dstamp = year + '-04-01'
+                            month = '04'
                         elif quarter == 'Q3':
-                            dstamp = year + '-07-01'
+                            month = '07'
                         elif quarter == 'Q4':
-                            dstamp = year + '-10-01'
+                            month = '10'
                         else:
                             raise Exception('Unsupported date quarter specification ' + line[0])
-
-                        timestamps.append(datetime.strptime(dstamp, '%Y-%m-%d'))
-                        data.append(numpy.asarray(line[1:], dtype=numpy.float64))
+                        date_string = year + '-' + month + '-01'
+                        format = '%Y-%m-%d'
                     else:
                         # TODO handle other date cases
                         raise Exception('Unsupported date specification ' + line[0])
+                    timestamps.append(datetime.strptime(date_string, format))
+                    data.append(numpy.asarray(line[1:], dtype=numpy.float64))
 
             return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
 

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -28,7 +28,13 @@ class DataWareHouse:
         self.VALID_VALUES = {
             'dataset_type': (
                 'timeseries',
-                'aggregate')}
+                'aggregate'),
+            'aggregation_unit': (
+                'Auto',
+                'Day',
+                'Month',
+                'Quarter',
+                'Year')}
 
         if not self.apikey:
             try:
@@ -200,6 +206,7 @@ class DataWareHouse:
         dimension_id = self.__get_id_from_descriptor(realm, 'dimensions', dimension)
 
         self.__validate_str('dataset_type', dataset_type)
+        self.__validate_str('aggregation_unit', aggregation_unit)
 
         config = {
             'operation': 'get_data',

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -191,14 +191,16 @@ class DataWareHouse:
                     filters={},
                     dataset_type='timeseries',
                     aggregation_unit='Auto'):
+        metric_id = self.__get_id_from_descriptor(realm, 'metrics', metric)
+        dimension_id = self.__get_id_from_descriptor(realm, 'dimensions', dimension)
 
         config = {
             'operation': 'get_data',
             'start_date': start,
             'end_date': end,
             'realm': realm,
-            'statistic': metric,
-            'group_by': dimension,
+            'statistic': metric_id,
+            'group_by': dimension_id,
             'dataset_type': dataset_type,
             'aggregation_unit': aggregation_unit,
             'public_user': 'true',
@@ -280,6 +282,13 @@ class DataWareHouse:
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
 
             return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
+
+    def __get_id_from_descriptor(self, realm, key, id):
+        list = self.__get_descriptor_id_text_info_list(realm, key)
+        output = next((i for (i, text, info) in list if id == i or id == text), None)
+        if output is None:
+            raise KeyError(key + ' key \'' + id + '\' not found in \'' + realm + '\' realm')
+        return output
 
     def get_usagedata(self, config):
         response = self.__request('/controllers/user_interface.php',

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -100,8 +100,8 @@ class DataWareHouse:
         return 'Not logged in'
 
     def get_realms(self):
-        info = self.__get_descriptor()
-        return [*info['realms']]
+        descriptor = self.__get_descriptor()
+        return tuple([*descriptor['realms']])
 
     def get_metrics(self, realm):
         info = self.__get_descriptor()

--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -237,9 +237,7 @@ class DataWareHouse:
             timestamps = []
             data = []
             for line_num, line in enumerate(csvdata):
-                if line_num == 1:
-                    title = line[0]
-                elif line_num == 5:
+                if line_num == 5:
                     start, end = line
                 elif line_num == 7:
                     dimensions = []


### PR DESCRIPTION
API changes:
timeseries() and aggregate() are now combined into get_dataset(), which returns a DataFrame
realms() is now get_realms()
metrics() is now get_metrics()
dimensions() is now get_dimensions()
get_descriptor() is now private __get_descriptor()
added method get_filters()
added member variable VALID_VALUES

Filters, duration, and aggregation unit can now be passed into get_dataset()

Duplicated code was moved into methods to avoid repetition.