### PR TITLE
Update plotly theme to set plot origin default.

### DIFF
--- a/xdmod/themes.py
+++ b/xdmod/themes.py
@@ -99,6 +99,7 @@ pio.templates["timeseries"] = go.layout.Template(
             'linecolor': '#c0cfe0',
             'zerolinecolor': '#c0cfe1',
             'showline': True,
+            'rangemode': 'tozero',
             'zerolinewidth': 4
         },
         'title': {


### PR DESCRIPTION
XDMoD starts at zero for the timeseries plots.

Before:

<img width="239" alt="image" src="https://user-images.githubusercontent.com/5342179/218112449-54c689f7-eab5-4db4-bfb3-6663cda83d72.png">

After:

<img width="266" alt="image" src="https://user-images.githubusercontent.com/5342179/218112322-c1073e0a-56f4-4fce-906f-4252ad6677fb.png">
