### PR TITLE
Add dimension name to metadata for timeseries data.

### DIFF
--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -321,7 +321,9 @@ class DataWareHouse:
                     timestamps.append(datetime.strptime(date_string, format))
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
 
-            return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
+            return pd.DataFrame(data=data,
+                                index=pd.Series(data=timestamps, name='Time'),
+                                columns=pd.Series(data=dimensions, name=dimension))
 
     def __get_id_from_descriptor(self, realm, key, id):
         list = self.__get_descriptor_id_text_info_list(realm, key)


### PR DESCRIPTION
Before:

<img width="361" alt="image" src="https://user-images.githubusercontent.com/5342179/218117093-80f127ef-c585-46c0-a0dd-e69e7c4bfb53.png">

After:

<img width="506" alt="image" src="https://user-images.githubusercontent.com/5342179/218116901-b286a918-b23e-414b-91aa-af5b83f389b0.png">
