### PR TITLE
Revert "Add dimension name to metadata for timeseries data."

### DIFF
--- a/xdmod/datawarehouse.py
+++ b/xdmod/datawarehouse.py
@@ -321,9 +321,7 @@ class DataWareHouse:
                     timestamps.append(datetime.strptime(date_string, format))
                     data.append(numpy.asarray(line[1:], dtype=numpy.float64))
 
-            return pd.DataFrame(data=data,
-                                index=pd.Series(data=timestamps, name='Time'),
-                                columns=pd.Series(data=dimensions, name=dimension))
+            return pd.DataFrame(data=data, index=pd.Series(data=timestamps, name='Time'), columns=dimensions)
 
     def __get_id_from_descriptor(self, realm, key, id):
         list = self.__get_descriptor_id_text_info_list(realm, key)


### PR DESCRIPTION
Reverts ubccr/xdmod-python#5