### PR TITLE
User agent

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pandas
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        sudo apt-get update
-        sudo apt-get install libssl-dev libcurl4-openssl-dev
         python -m pip install -e .
     - name: Lint with flake8
       run: |

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'numpy',
         'pandas',
-        'pycurl',
-        'plotly'
+        'plotly',
+        'requests',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup, find_packages
+from xdmod.__version__ import __title__, __version__, __description__
+
 setup(
-    name="xdmod",
-    version="0.0.15",
-    description='Python driver for XDMoD',
+    name=__title__,
+    version=__version__,
+    description=__description__,
     license='LGPLv3',
     author='Joseph P White',
     author_email='jpwhite4@buffalo.edu',

--- a/xdmod/__init__.py
+++ b/xdmod/__init__.py
@@ -1,1 +1,1 @@
-""" Driver module for XDMoD """
+from .__version__ import __version__

--- a/xdmod/__version__.py
+++ b/xdmod/__version__.py
@@ -1,0 +1,3 @@
+__title__ = 'xdmod'
+__version__ = '1.0.0-alpha.1'
+__description__ = 'Python driver for XDMoD'

--- a/xdmod/_http_requester.py
+++ b/xdmod/_http_requester.py
@@ -3,6 +3,7 @@ import os
 import requests
 from urllib.parse import urlencode
 import xdmod._validator as _validator
+from xdmod.__version__ import __title__, __version__
 
 
 class _HttpRequester:
@@ -16,7 +17,10 @@ class _HttpRequester:
             raise KeyError(
                 '`XDMOD_API_TOKEN` environment variable has not been set.'
             ) from None
-        self.__headers = {'Authorization': 'Bearer ' + self.__api_token}
+        self.__headers = {
+            'Authorization': 'Bearer ' + self.__api_token,
+            'User-Agent': __title__ + ' Python v' + __version__,
+        }
         self.__requests_session = None
         self.__raw_data_limit = None
 

--- a/xdmod/_http_requester.py
+++ b/xdmod/_http_requester.py
@@ -1,7 +1,7 @@
 import io
 import json
 import os
-import pycurl
+import requests
 from urllib.parse import urlencode
 import xdmod._validator as _validator
 
@@ -17,18 +17,18 @@ class _HttpRequester:
             raise KeyError(
                 '`XDMOD_API_TOKEN` environment variable has not been set.'
             ) from None
-        self.__headers = ['Authorization: Bearer ' + self.__api_token]
-        self.__crl = None
+        self.__headers = {'Authorization': 'Bearer ' + self.__api_token}
+        self.__requests_session = None
         self.__raw_data_limit = None
 
     def _start_up(self):
         self.__in_runtime_context = True
-        self.__crl = pycurl.Curl()
+        self.__requests_session = requests.Session()
         self.__assert_connection_to_xdmod_host()
 
     def _tear_down(self):
-        if self.__crl:
-            self.__crl.close()
+        if self.__requests_session is not None:
+            self.__requests_session.close()
         self.__in_runtime_context = False
 
     def _request_data(self, params):
@@ -74,40 +74,33 @@ class _HttpRequester:
 
     def __request(self, path='', post_fields=None):
         _validator._assert_runtime_context(self.__in_runtime_context)
-        self.__crl.reset()
         url = self.__xdmod_host + path
         if post_fields:
             post_fields['Bearer'] = self.__api_token
-            self.__crl.setopt(pycurl.POSTFIELDS, urlencode(post_fields))
+            response = self.__requests_session.post(
+                url,
+                headers=self.__headers,
+                data=post_fields,
+            )
         else:
             url += '&' if '?' in url else '?'
             url += 'Bearer=' + self.__api_token
-        self.__crl.setopt(pycurl.URL, url)
-        self.__crl.setopt(pycurl.HTTPHEADER, self.__headers)
-        buffer = io.BytesIO()
-        self.__crl.setopt(pycurl.WRITEDATA, buffer)
-        try:
-            self.__crl.perform()
-        except pycurl.error as e:
-            code, msg = e.args
-            if code == pycurl.E_URL_MALFORMAT:
-                msg = 'Malformed URL.'
-            raise RuntimeError(msg) from None
-        response = buffer.getvalue().decode()
-        code = self.__crl.getinfo(pycurl.RESPONSE_CODE)
-        if code != 200:
+            response = self.__requests_session.get(url, headers=self.__headers)
+        if response.status_code != 200:
             msg = ''
             try:
-                response_json = json.loads(response)
+                response_json = json.loads(response.text)
                 msg = ': ' + response_json['message']
             except json.JSONDecodeError:
                 pass
-            if code == 401:
+            if response.status_code == 401:
                 msg = (
                     ': Make sure XDMOD_API_TOKEN is set to a valid API token.'
                 )
-            raise RuntimeError('Error ' + str(code) + msg) from None
-        return response
+            raise RuntimeError(
+                'Error ' + str(response.status_code) + msg
+            ) from None
+        return response.text
 
     def __get_data_post_fields(self, params):
         post_fields = {

--- a/xdmod/_http_requester.py
+++ b/xdmod/_http_requester.py
@@ -1,4 +1,3 @@
-import io
 import json
 import os
 import requests


### PR DESCRIPTION
This adds a `User-Agent` header so the package can be identified in requests to the XDMoD portal.

This PR is a fork of [this one](https://github.com/ubccr/xdmod-python/pull/9). The diff is [here](https://github.com/aaronweeden/xdmod-python/compare/requests...user-agent). If the other PR is not approved, this one can be changed to add the header to PyCurl instead.